### PR TITLE
Add php 7.4 to travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.4
 
 before_script:
   - composer self-update


### PR DESCRIPTION
This PR adds PHP 7.4 support to the Travis builds.