### PR TITLE
Pulling in PHP SDK v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 env:
   matrix:
-    - ILLUMINATE_VERSION="^5.8"
     - ILLUMINATE_VERSION="^6.0"
     - ILLUMINATE_VERSION="^7.0"
 #    Add other versions here to test against multiple framework versions
@@ -9,14 +8,7 @@ env:
 
 language: php
 
-# Laravel 5 is the only Laravel we support that's compatible with PHP v7.1
-jobs:
-  include:
-    - php: 7.1
-      env: ILLUMINATE_VERSION="^5.8"
-
 php:
-  - 7.2
   - 7.3
   - 7.4
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Help Scout Service Provider can be installed via [Composer](http://getcompos
 ```json
 {
     "require": {
-        "helpscout/api-laravel": "~1.0"
+        "helpscout/api-laravel": "~2.0"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "source": "https://github.com/helpscout/helpscout-api-php-laravel"
   },
   "require": {
-    "php": "^7.1",
+    "php": "^7.3",
     "helpscout/api": "~3.0",
     "illuminate/support": "^5.6|^6.0|^7.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   },
   "require": {
     "php": "^7.1",
-    "helpscout/api": "~2.0",
+    "helpscout/api": "~3.0",
     "illuminate/support": "^5.6|^6.0|^7.0"
   },
   "require-dev": {


### PR DESCRIPTION
Addresses https://github.com/helpscout/helpscout-api-php-laravel/issues/8 by pulling in v3 of the SDK.  This targets `v2.0` for this repo once merged.