### PR TITLE
Supporting PHP 8 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 env:
   matrix:
-    - ILLUMINATE_VERSION="^6.0"
     - ILLUMINATE_VERSION="^7.0"
     - ILLUMINATE_VERSION="^8.0"
 #    Add other versions here to test against multiple framework versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
 #    Add other versions here to test against multiple framework versions
   global:
     - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)
+    - XDEBUG_MODE=coverage
 
 language: php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 8.0
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 env:
   matrix:
-    - ILLUMINATE_VERSION="^7.0"
     - ILLUMINATE_VERSION="^8.0"
 #    Add other versions here to test against multiple framework versions
   global:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "illuminate/support": "^5.6|^6.0|^7.0|^8.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0",
+    "phpunit/phpunit": "^8.0",
     "phpstan/phpstan": "^0.12",
     "friendsofphp/php-cs-fixer": "^2.3"
   },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "source": "https://github.com/helpscout/helpscout-api-php-laravel"
   },
   "require": {
-    "php": "^7.1",
+    "php": "^7.1|^8.0",
     "helpscout/api": "~2.0",
     "illuminate/support": "^5.6|^6.0"
   },

--- a/tests/LaravelServiceProviderTest.php
+++ b/tests/LaravelServiceProviderTest.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Application;
 
 class LaravelServiceProviderTest extends ServiceProviderTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists(Application::class)) {
             $this->markTestSkipped();

--- a/tests/LaravelServiceProviderTest.php
+++ b/tests/LaravelServiceProviderTest.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Application;
 
 class LaravelServiceProviderTest extends ServiceProviderTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (!class_exists(Application::class)) {
             $this->markTestSkipped();

--- a/tests/LumenServiceProviderTest.php
+++ b/tests/LumenServiceProviderTest.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Application;
 
 class LumenServiceProviderTest extends ServiceProviderTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists(Application::class)) {
             $this->markTestSkipped();

--- a/tests/LumenServiceProviderTest.php
+++ b/tests/LumenServiceProviderTest.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Application;
 
 class LumenServiceProviderTest extends ServiceProviderTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (!class_exists(Application::class)) {
             $this->markTestSkipped();

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -18,7 +18,7 @@ abstract class ServiceProviderTest extends TestCase
      */
     protected $app;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->app = $this->setupApplication();

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -18,7 +18,7 @@ abstract class ServiceProviderTest extends TestCase
      */
     protected $app;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->app = $this->setupApplication();


### PR DESCRIPTION
Fulfills https://github.com/helpscout/helpscout-api-php-laravel/issues/11

This drops support for Laravel 6 & 7, leaving only supporting Laravel 8.  This will be tagged as v3.0 when released.